### PR TITLE
Renew within 14 days instead of 7

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ LE.create = function (le) {
     agreeCb(new Error("'agreeToTerms' was not supplied to LE and 'agreeTos' was not supplied to LE.register"));
   };
 
-  if (!le.renewWithin) { le.renewWithin = 7 * DAY; }
+  if (!le.renewWithin) { le.renewWithin = 14 * DAY; }
   // renewBy has a default in le-sni-auto
 
   if (!le.server) {


### PR DESCRIPTION
It seems like letsencrypt start sending out warning emails 10 days before the certificate expires. We got them and paniced a little wondering if the auto renewal actually works. With this change the user shouldn't get such an email because it has already renewed. 